### PR TITLE
docs: add permalinks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.mark
   - attr_list
+  - toc:
+      permalink: '🔗'
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
![Screenshot 2024-08-26 at 14 18 27](https://github.com/user-attachments/assets/07b53666-096f-4c29-b0e0-88d359b7fa45)

allows creating link to sections within a page

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enable permalinks for section headers in the documentation by updating the mkdocs configuration.

Documentation:
- Add permalinks to section headers in the documentation to enable easy linking to specific sections.

<!-- Generated by sourcery-ai[bot]: end summary -->